### PR TITLE
Update custom_rikai.openapi.json

### DIFF
--- a/custom_rikai.openapi.json
+++ b/custom_rikai.openapi.json
@@ -357,10 +357,10 @@
         }
       }
     },
-    "/rikai/zip/async/{document_id}/{custom_model_id}": {
+    "/rikai/zip/async/{statusId}/{custom_model_id}": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/{custom_model_id}?async=True` or `/rikai/bulk/{custom_model_id}`. Identifiable by document ID or status ID.",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/{custom_model_id}?async=True` or `/rikai/bulk/{custom_model_id}`. Identifiable by statusId.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -2012,7 +2012,7 @@
   },
   "servers": [
     {
-      "url": "https://api.lazarusforms.com/api",
+      "url": "https://api.lazarusai.com/api",
       "description": ""
     }
   ]


### PR DESCRIPTION
- Changed description of async status endpoint as it was inaccurate (said document_id could be used to retrieve status when this is false, only statusId can be used)
- changed the async status endpoint from /rikai/zip/async/{document_id}/{custom_model_id} to /rikai/zip/async/{statusId}/{custom_model_id} (although custom model names need to be changed in the future too) 
- changed lazarusforms to lazarusai