### PR TITLE
Update extract.openapi.json

### DIFF
--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -224,10 +224,10 @@
         }
       }
     },
-    "/rikai/zip/async/{document_id}/RikAI2-Extract": {
+    "/rikai/zip/async/{statusId}/RikAI2-Extract": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/RikAI2-Extract?async=True` or `/rikai/bulk/RikAI2-Extract`. Identifiable by document ID or status ID.",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/RikAI2-Extract?async=True` or `/rikai/bulk/RikAI2-Extract`. Identifiable by statusId.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -1843,7 +1843,7 @@
   },
   "servers": [
     {
-      "url": "https://api.lazarusforms.com/api",
+      "url": "https://api.lazarusai.com/api",
       "description": ""
     }
   ]


### PR DESCRIPTION
- Changed description of async status endpoint as it was inaccurate (said document_id could be used to retrieve status when this is false, only statusId can be used)
- changed the async status endpoint from /rikai/zip/async/{document_id}/{custom_model_id} to /rikai/zip/async/{statusId}/{custom_model_id} (although custom model names need to be changed in the future too)
- changed lazarusforms to lazarusai