### PR TITLE
Update rikai2.openapi.json

### DIFF
--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -150,10 +150,10 @@
         "x-internal": true
       }
     },
-    "/rikai/zip/async/{document_id}": {
+    "/rikai/zip/async/{statusId}": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip?async=True` or `/rikai/bulk`. Identifiable by status ID (the {document_id} part of the URL).",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/zip?async=True` or `/rikai/bulk`. Identifiable by statusId.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -1763,7 +1763,7 @@
   },
   "servers": [
     {
-      "url": "https://api.lazarusforms.com/api",
+      "url": "https://api.lazarusai.com/api",
       "description": ""
     }
   ]


### PR DESCRIPTION
- Changed description of async status endpoint as it was inaccurate (said document_id could be used to retrieve status when this is false, only statusId can be used)
- changed the async status endpoint from /rikai/zip/async/{document_id}/{custom_model_id} to /rikai/zip/async/{statusId}/{custom_model_id} (although custom model names need to be changed in the future too)
- changed lazarusforms to lazarusai