### PR TITLE
Update riky2.openapi.json

### DIFF
--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -287,10 +287,10 @@
         }
       }
     },
-    "/rikai/zip/async/{document_id}/riky2": {
+    "/rikai/zip/async/{statusId}/riky2": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/riky2?async=True` or `/rikai/bulk/riky2`. Identifiable by document ID or status ID.",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/riky2?async=True` or `/rikai/bulk/riky2`. Identifiable by statusId.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -1833,7 +1833,7 @@
   },
   "servers": [
     {
-      "url": "https://api.lazarusforms.com/api",
+      "url": "https://api.lazarusai.com/api",
       "description": ""
     }
   ]


### PR DESCRIPTION
- Changed description of async status endpoint as it was inaccurate (said document_id could be used to retrieve status when this is false, only statusId can be used)
- changed the async status endpoint from /rikai/zip/async/{document_id}/{custom_model_id} to /rikai/zip/async/{statusId}/{custom_model_id} (although custom model names need to be changed in the future too)
- changed lazarusforms to lazarusai