### PR TITLE
2025 02 27 Request Examples, Move chat endpoint

### DIFF
--- a/custom_rikai.openapi.json
+++ b/custom_rikai.openapi.json
@@ -646,8 +646,9 @@
               }
             ],
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.\n",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "outputURL": {
             "type": "string",
@@ -771,8 +772,9 @@
               }
             ],
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.\n",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "outputURL": {
             "type": "string",

--- a/custom_rikai.openapi.json
+++ b/custom_rikai.openapi.json
@@ -648,7 +648,7 @@
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.\n",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "outputURL": {
             "type": "string",
@@ -774,7 +774,7 @@
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.\n",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "outputURL": {
             "type": "string",

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -626,9 +626,7 @@
       "BulkURLRequest": {
         "examples": [
           {
-            "inputURL": [
-              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
-            ],
+            "inputURL": "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c",
             "question": {
               "PatientInfo": {
                 "FirstName": {
@@ -641,26 +639,21 @@
                 }
               }
             },
-            "webhook": "string",
+            "webhook": null,
             "settings": {
               "returnConfidence": true
             },
-            "webhookHeaders": {},
+            "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
-            "metadata": {},
-            "outputURL": "string",
-            "outputURLHeaders": {},
+            "metadata": null,
+            "outputURL": null,
+            "outputURLHeaders": null,
             "returnJSON": true,
-            "sftp": {
-              "user": "string",
-              "password": "string",
-              "privateKey": "string",
-              "privateKeyPassphrase": "string"
-            },
+            "sftp": null,
             "staticIP": false
           }
         ],
@@ -1252,9 +1245,7 @@
       "RikAIURLRequest": {
         "examples": [
           {
-            "inputURL": [
-              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
-            ],
+            "inputURL": "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c",
             "question": {
               "PatientInfo": {
                 "FirstName": {
@@ -1267,26 +1258,21 @@
                 }
               }
             },
-            "webhook": "string",
+            "webhook": null,
             "settings": {
               "returnConfidence": true
             },
-            "webhookHeaders": {},
+            "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
-            "metadata": {},
-            "outputURL": "string",
-            "outputURLHeaders": {},
+            "metadata": null,
+            "outputURL": null,
+            "outputURLHeaders": null,
             "returnJSON": true,
-            "sftp": {
-              "user": "string",
-              "password": "string",
-              "privateKey": "string",
-              "privateKeyPassphrase": "string"
-            },
+            "sftp": null,
             "staticIP": false
           }
         ],
@@ -1656,9 +1642,7 @@
       "ZipURLRequest": {
         "examples": [
           {
-            "inputURL": [
-              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
-            ],
+            "inputURL": "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c",
             "question": {
               "PatientInfo": {
                 "FirstName": {
@@ -1671,26 +1655,21 @@
                 }
               }
             },
-            "webhook": "string",
+            "webhook": null,
             "settings": {
               "returnConfidence": true
             },
-            "webhookHeaders": {},
+            "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
-            "language": "string",
-            "metadata": {},
-            "outputURL": "string",
-            "outputURLHeaders": {},
+            "language": "en",
+            "metadata": null,
+            "outputURL": null,
+            "outputURLHeaders": null,
             "returnJSON": true,
-            "sftp": {
-              "user": "string",
-              "password": "string",
-              "privateKey": "string",
-              "privateKeyPassphrase": "string"
-            },
+            "sftp": null,
             "staticIP": false
           }
         ],

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -499,7 +499,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -730,7 +730,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceBase64": {
@@ -883,7 +883,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -955,7 +955,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -1031,7 +1031,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceBase64": {
@@ -1126,7 +1126,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "inputURL": {
@@ -1337,7 +1337,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceBase64": {
@@ -1518,7 +1518,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -1741,7 +1741,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+             "sample_form_1"
             ]
           },
           "forceBase64": {

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -654,7 +654,7 @@
             "metadata": {},
             "outputURL": "string",
             "outputURLHeaders": {},
-            "returnJSON": false,
+            "returnJSON": true,
             "sftp": {
               "user": "string",
               "password": "string",
@@ -1280,7 +1280,7 @@
             "metadata": {},
             "outputURL": "string",
             "outputURLHeaders": {},
-            "returnJSON": false,
+            "returnJSON": true,
             "sftp": {
               "user": "string",
               "password": "string",
@@ -1684,7 +1684,7 @@
             "metadata": {},
             "outputURL": "string",
             "outputURLHeaders": {},
-            "returnJSON": false,
+            "returnJSON": true,
             "sftp": {
               "user": "string",
               "password": "string",

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -1258,7 +1258,7 @@
                 }
               }
             },
-            "webhook": "YOUR_WEBHOOK_URL",
+            "webhook": null,
             "settings": {
               "returnConfidence": true
             },

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -639,7 +639,7 @@
                 }
               }
             },
-            "webhook": null,
+            "webhook": "YOUR_WEBHOOK_URL",
             "settings": {
               "returnConfidence": true
             },
@@ -1258,7 +1258,7 @@
                 }
               }
             },
-            "webhook": null,
+            "webhook": "YOUR_WEBHOOK_URL",
             "settings": {
               "returnConfidence": true
             },
@@ -1655,7 +1655,7 @@
                 }
               }
             },
-            "webhook": null,
+            "webhook": "YOUR_WEBHOOK_URL",
             "settings": {
               "returnConfidence": true
             },

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -499,7 +499,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -647,7 +647,7 @@
             },
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "sample_form_1",
+            "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
@@ -730,7 +730,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceBase64": {
@@ -883,7 +883,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -955,7 +955,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -1031,7 +1031,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceBase64": {
@@ -1126,7 +1126,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "inputURL": {
@@ -1273,7 +1273,7 @@
             },
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "sample_form_1",
+            "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
@@ -1337,7 +1337,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceBase64": {
@@ -1518,7 +1518,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -1677,7 +1677,7 @@
             },
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "sample_form_1",
+            "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "string",
@@ -1741,7 +1741,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-             "sample_form_1"
+             "file1.pdf"
             ]
           },
           "forceBase64": {

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -624,6 +624,46 @@
         "title": "BulkResponse"
       },
       "BulkURLRequest": {
+        "examples": [
+          {
+            "inputURL": [
+              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
+            ],
+            "question": {
+              "PatientInfo": {
+                "FirstName": {
+                  "data": "Patient first name",
+                  "page_number": 0
+                },
+                "LastName": {
+                  "data": "Patient last name",
+                  "page_number": 0
+                }
+              }
+            },
+            "webhook": "string",
+            "settings": {
+              "returnConfidence": true
+            },
+            "webhookHeaders": {},
+            "webhookSendFull": true,
+            "fileId": "sample_form_1",
+            "forceBase64": false,
+            "forceOCR": false,
+            "language": "en",
+            "metadata": {},
+            "outputURL": "string",
+            "outputURLHeaders": {},
+            "returnJSON": false,
+            "sftp": {
+              "user": "string",
+              "password": "string",
+              "privateKey": "string",
+              "privateKeyPassphrase": "string"
+            },
+            "staticIP": false
+          }
+        ],
         "properties": {
           "inputURL": {
             "anyOf": [
@@ -1210,6 +1250,46 @@
         "title": "RikAIResponse"
       },
       "RikAIURLRequest": {
+        "examples": [
+          {
+            "inputURL": [
+              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
+            ],
+            "question": {
+              "PatientInfo": {
+                "FirstName": {
+                  "data": "Patient first name",
+                  "page_number": 0
+                },
+                "LastName": {
+                  "data": "Patient last name",
+                  "page_number": 0
+                }
+              }
+            },
+            "webhook": "string",
+            "settings": {
+              "returnConfidence": true
+            },
+            "webhookHeaders": {},
+            "webhookSendFull": true,
+            "fileId": "sample_form_1",
+            "forceBase64": false,
+            "forceOCR": false,
+            "language": "en",
+            "metadata": {},
+            "outputURL": "string",
+            "outputURLHeaders": {},
+            "returnJSON": false,
+            "sftp": {
+              "user": "string",
+              "password": "string",
+              "privateKey": "string",
+              "privateKeyPassphrase": "string"
+            },
+            "staticIP": false
+          }
+        ],
         "properties": {
           "inputURL": {
             "type": "string",
@@ -1574,6 +1654,46 @@
         "title": "ZipResponse"
       },
       "ZipURLRequest": {
+        "examples": [
+          {
+            "inputURL": [
+              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
+            ],
+            "question": {
+              "PatientInfo": {
+                "FirstName": {
+                  "data": "Patient first name",
+                  "page_number": 0
+                },
+                "LastName": {
+                  "data": "Patient last name",
+                  "page_number": 0
+                }
+              }
+            },
+            "webhook": "string",
+            "settings": {
+              "returnConfidence": true
+            },
+            "webhookHeaders": {},
+            "webhookSendFull": true,
+            "fileId": "sample_form_1",
+            "forceBase64": false,
+            "forceOCR": false,
+            "language": "string",
+            "metadata": {},
+            "outputURL": "string",
+            "outputURLHeaders": {},
+            "returnJSON": false,
+            "sftp": {
+              "user": "string",
+              "password": "string",
+              "privateKey": "string",
+              "privateKeyPassphrase": "string"
+            },
+            "staticIP": false
+          }
+        ],
         "properties": {
           "inputURL": {
             "type": "string",

--- a/forms.openapi.json
+++ b/forms.openapi.json
@@ -669,7 +669,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -681,7 +681,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "outputURL": {
             "type": "string",
@@ -770,7 +770,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -838,7 +838,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -906,7 +906,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -983,7 +983,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -1026,7 +1026,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "webhookHeaders": {
             "type": "object",
@@ -1055,7 +1055,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -1098,7 +1098,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "webhookHeaders": {
             "type": "object",
@@ -1127,7 +1127,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -1170,7 +1170,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "webhookHeaders": {
             "type": "object",

--- a/forms.openapi.json
+++ b/forms.openapi.json
@@ -670,8 +670,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -770,8 +771,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -837,8 +839,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -904,8 +907,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -980,8 +984,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",
@@ -1051,8 +1056,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",
@@ -1122,8 +1128,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",

--- a/forms.openapi.json
+++ b/forms.openapi.json
@@ -672,7 +672,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -773,7 +773,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -841,7 +841,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -909,7 +909,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -986,7 +986,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1058,7 +1058,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1130,7 +1130,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",

--- a/ocr.openapi.json
+++ b/ocr.openapi.json
@@ -203,7 +203,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",
@@ -279,7 +279,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",
@@ -570,7 +570,7 @@
             "title": "fileId",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",

--- a/ocr.openapi.json
+++ b/ocr.openapi.json
@@ -202,7 +202,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",
@@ -277,7 +278,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",
@@ -567,7 +569,8 @@
             "type": "string",
             "title": "fileId",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",

--- a/ocr.openapi.json
+++ b/ocr.openapi.json
@@ -201,7 +201,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -277,7 +277,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -568,7 +568,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },

--- a/old_forms.openapi.json
+++ b/old_forms.openapi.json
@@ -694,7 +694,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -729,7 +729,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           }
         },
         "type": "object",
@@ -791,7 +791,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -851,7 +851,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "webhook": {
             "type": "string",
@@ -900,7 +900,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -979,7 +979,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -994,7 +994,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -1039,7 +1039,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -1054,7 +1054,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "webhook": {
             "type": "string",
@@ -1098,7 +1098,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -1113,7 +1113,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",

--- a/old_ocr.openapi.json
+++ b/old_ocr.openapi.json
@@ -197,7 +197,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -271,7 +271,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -568,7 +568,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -654,7 +654,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -695,7 +695,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",

--- a/old_other_forms.openapi.json
+++ b/old_other_forms.openapi.json
@@ -625,7 +625,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -685,7 +685,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "webhook": {
             "type": "string",
@@ -734,7 +734,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -813,7 +813,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -828,7 +828,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -873,7 +873,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -888,7 +888,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "webhook": {
             "type": "string",
@@ -932,7 +932,7 @@
           "fileId": {
             "type": "string",
             "title": "fileId",
-            "description": "Custom ID for document. If not present, will default to file name."
+            "description": "Custom ID for document. If not present, will default to a random UUID."
           },
           "forceBase64": {
             "type": "boolean",
@@ -947,7 +947,7 @@
           "statusId": {
             "type": "string",
             "title": "statusId",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",

--- a/other_forms.openapi.json
+++ b/other_forms.openapi.json
@@ -530,7 +530,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -594,7 +594,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -652,7 +652,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "metadata": {
             "type": "object",
@@ -732,7 +732,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",
@@ -796,7 +796,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",
@@ -858,7 +858,7 @@
             "type": "string",
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceBase64": {
             "type": "boolean",

--- a/other_forms.openapi.json
+++ b/other_forms.openapi.json
@@ -528,7 +528,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -592,7 +592,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -650,7 +650,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -730,7 +730,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -746,7 +746,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",
@@ -794,7 +794,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -810,7 +810,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "webhook": {
             "type": "string",
@@ -856,7 +856,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "default": "UUID",
             "examples": "file1.pdf"
           },
@@ -872,7 +872,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to file name."
+            "description": "WARNING: Deprecating in favor of 'fileId'. Custom ID for document. If not present, will default to a random UUID."
           },
           "metadata": {
             "type": "object",

--- a/other_forms.openapi.json
+++ b/other_forms.openapi.json
@@ -529,7 +529,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -592,7 +593,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -649,7 +651,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "metadata": {
             "type": "object",
@@ -728,7 +731,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",
@@ -791,7 +795,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",
@@ -852,7 +857,8 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "default": "file name"
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceBase64": {
             "type": "boolean",

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -442,6 +442,30 @@
         "title": "BulkResponse"
       },
       "BulkURLRequest": {
+        "examples": {
+          "inputURL": [
+            "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
+          ],
+          "question": "What is the name of the patient?",
+          "webhook": "YOUR_WEBHOOK_URL",
+          "settings": {
+            "advancedExplainability": false,
+            "advancedVision": false
+          },
+          "webhookHeaders": null,
+          "webhookSendFull": true,
+          "fileId": "file1.pdf",
+          "forceBase64": false,
+          "forceOCR": false,
+          "language": "en",
+          "metadata": null,
+          "outputURL": null,
+          "outputURLHeaders": null,
+          "returnJSON": true,
+          "returnOCR": false,
+          "sftp": null,
+          "staticIP": false
+        },
         "properties": {
           "inputURL": {
             "anyOf": [

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -442,7 +442,7 @@
         "title": "BulkResponse"
       },
       "BulkURLRequest": {
-        "examples": {
+        "examples": [{
           "inputURL": [
             "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
           ],
@@ -465,7 +465,7 @@
           "returnOCR": false,
           "sftp": null,
           "staticIP": false
-        },
+        }],
         "properties": {
           "inputURL": {
             "anyOf": [

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -1115,8 +1115,7 @@
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
               [
-                "What is the first medication listed under Section C - Medical Information?",
-                "What is its strength?"
+                "Tell me about the history of AI"
               ]
             ]
           },
@@ -1133,18 +1132,6 @@
             "type": "boolean",
             "description": "Receive the full JSON response at the webhook URL upon request completion. Set to `false` to only receive request status.",
             "default": true
-          },
-          "fileId": {
-            "type": "string",
-            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
-            "examples": [
-              "sample_form_1"
-            ]
-          },
-          "forceOCR": {
-            "type": "boolean",
-            "description": "Will rasterize a pdf. Set this parameter to `true` only if the input file is a fillable pdf.",
-            "default": false
           },
           "language": {
             "type": "string",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -817,9 +817,7 @@
       "BulkURLRequest": {
         "examples": [
           {
-            "inputURL": [
-              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
-            ],
+            "inputURL": "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c",
             "question": [
               [
                 "What is the name of the patient?"
@@ -829,25 +827,20 @@
                 "What is its strength?"
               ]
             ],
-            "webhook": "string",
-            "settings": {},
-            "webhookHeaders": {},
+            "webhook": null,
+            "settings": null,
+            "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
-            "metadata": {},
-            "outputURL": "string",
-            "outputURLHeaders": {},
+            "metadata": null,
+            "outputURL": null,
+            "outputURLHeaders": null,
             "returnJSON": true,
             "returnOCR": false,
-            "sftp": {
-              "user": "string",
-              "password": "string",
-              "privateKey": "string",
-              "privateKeyPassphrase": "string"
-            },
+            "sftp": null,
             "staticIP": false
           }
         ],
@@ -1443,22 +1436,17 @@
                 "What is its strength?"
               ]
             ],
-            "webhook": "string",
-            "webhookHeaders": {},
+            "webhook": null,
+            "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
-            "metadata": {},
-            "ocr": {},
+            "metadata": null,
+            "ocr": null,
             "returnOCR": false,
-            "sftp": {
-            "user": "string",
-            "password": "string",
-            "privateKey": "string",
-            "privateKeyPassphrase": "string"
-            },
+            "sftp": null,
             "staticIP": false
           }
         ],

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -17,89 +17,6 @@
     "summary": ""
   },
   "paths": {
-    "/rikai/chat/riky2": {
-      "post": {
-        "summary": "Chat, no file input, JSON response",
-        "description": "Make a RikY2 request using prompt as context. No document upload.",
-        "operationId": "post_chat_riky2",
-        "parameters": [
-          {
-            "name": "orgId",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9\\-_]+$",
-              "title": "orgId",
-              "description": "Organization ID"
-            },
-            "description": "Organization ID"
-          },
-          {
-            "name": "authKey",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9\\-_]+$",
-              "title": "authKey",
-              "description": "Authentication key"
-            },
-            "description": "Authentication key"
-          },
-          {
-            "name": "apiVersion",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "apiVersion",
-              "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header."
-            },
-            "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header."
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RikAIChatRequestBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RikAIResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          },
-          "502": {
-            "$ref": "#/components/responses/502"
-          }
-        }
-      }
-    },
     "/rikai/custom/riky2": {
       "post": {
         "summary": "Document input, JSON response",
@@ -442,6 +359,89 @@
           },
           "207": {
             "$ref": "#/components/responses/207"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
+          }
+        }
+      }
+    },
+    "/rikai/chat/riky2": {
+      "post": {
+        "summary": "Chat, no file input, JSON response",
+        "description": "Make a RikY2 request using prompt as context. No document upload.",
+        "operationId": "post_chat_riky2",
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9\\-_]+$",
+              "title": "orgId",
+              "description": "Organization ID"
+            },
+            "description": "Organization ID"
+          },
+          {
+            "name": "authKey",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9\\-_]+$",
+              "title": "authKey",
+              "description": "Authentication key"
+            },
+            "description": "Authentication key"
+          },
+          {
+            "name": "apiVersion",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "apiVersion",
+              "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header."
+            },
+            "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RikAIChatRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RikAIResponse"
+                }
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/400"

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -827,7 +827,7 @@
                 "What is its strength?"
               ]
             ],
-            "webhook": null,
+            "webhook": "YOUR_WEBHOOK_URL",
             "settings": null,
             "webhookHeaders": null,
             "webhookSendFull": true,
@@ -1436,7 +1436,7 @@
                 "What is its strength?"
               ]
             ],
-            "webhook": null,
+            "webhook": "YOUR_WEBHOOK_URL",
             "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -1436,7 +1436,7 @@
                 "What is its strength?"
               ]
             ],
-            "webhook": "YOUR_WEBHOOK_URL",
+            "webhook": null,
             "webhookHeaders": null,
             "webhookSendFull": true,
             "fileId": "file1.pdf",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -840,7 +840,7 @@
             "metadata": {},
             "outputURL": "string",
             "outputURLHeaders": {},
-            "returnJSON": false,
+            "returnJSON": true,
             "returnOCR": false,
             "sftp": {
               "user": "string",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -685,7 +685,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -833,7 +833,7 @@
             "settings": {},
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "file name",
+            "fileId": "sample_form_1",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
@@ -911,7 +911,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceBase64": {
@@ -1063,7 +1063,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -1138,7 +1138,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -1208,7 +1208,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceBase64": {
@@ -1263,7 +1263,7 @@
             "webhook": "string",
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "file name",
+            "fileId": "sample_form_1",
             "language": "en",
             "metadata": {},
             "returnOCR": false,
@@ -1316,7 +1316,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "language": {
@@ -1459,7 +1459,7 @@
             "webhook": "string",
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "file name",
+            "fileId": "sample_form_1",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
@@ -1516,7 +1516,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceBase64": {
@@ -1695,7 +1695,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceOCR": {
@@ -1881,7 +1881,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name"
+              "sample_form_1"
             ]
           },
           "forceBase64": {

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -685,7 +685,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -833,7 +833,7 @@
             "settings": {},
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "sample_form_1",
+            "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
@@ -911,7 +911,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceBase64": {
@@ -1063,7 +1063,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -1195,7 +1195,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceBase64": {
@@ -1250,7 +1250,7 @@
             "webhook": "string",
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "sample_form_1",
+            "fileId": "file1.pdf",
             "language": "en",
             "metadata": {},
             "returnOCR": false,
@@ -1303,7 +1303,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "language": {
@@ -1446,7 +1446,7 @@
             "webhook": "string",
             "webhookHeaders": {},
             "webhookSendFull": true,
-            "fileId": "sample_form_1",
+            "fileId": "file1.pdf",
             "forceBase64": false,
             "forceOCR": false,
             "language": "en",
@@ -1503,7 +1503,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceBase64": {
@@ -1682,7 +1682,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceOCR": {
@@ -1868,7 +1868,7 @@
             "type": "string",
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "sample_form_1"
+              "file1.pdf"
             ]
           },
           "forceBase64": {

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -815,6 +815,42 @@
         "title": "BulkResponse"
       },
       "BulkURLRequest": {
+        "examples": [
+          {
+            "inputURL": [
+              "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c"
+            ],
+            "question": [
+              [
+                "What is the name of the patient?"
+              ],
+              [
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
+              ]
+            ],
+            "webhook": "string",
+            "settings": {},
+            "webhookHeaders": {},
+            "webhookSendFull": true,
+            "fileId": "file name",
+            "forceBase64": false,
+            "forceOCR": false,
+            "language": "en",
+            "metadata": {},
+            "outputURL": "string",
+            "outputURLHeaders": {},
+            "returnJSON": false,
+            "returnOCR": false,
+            "sftp": {
+              "user": "string",
+              "password": "string",
+              "privateKey": "string",
+              "privateKeyPassphrase": "string"
+            },
+            "staticIP": false
+          }
+        ],
         "properties": {
           "inputURL": {
             "anyOf": [
@@ -1212,6 +1248,34 @@
         "title": "RikAIFileRequest"
       },
       "RikAIOCRRequestBody": {
+        "examples": [
+          {
+            "ocr": {},
+            "question": [
+              [
+                "What is the name of the patient?"
+              ],
+              [
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
+              ]
+            ],
+            "webhook": "string",
+            "webhookHeaders": {},
+            "webhookSendFull": true,
+            "fileId": "file name",
+            "language": "en",
+            "metadata": {},
+            "returnOCR": false,
+            "sftp": {
+            "user": "string",
+            "password": "string",
+            "privateKey": "string",
+            "privateKeyPassphrase": "string"
+            },
+            "staticIP": false
+          }
+        ],
         "properties": {
           "ocr": {
             "description": "OCR data for the document (entire response from [OCR endpoint](../../ocr/ocr_v2), [example here](https://docs.google.com/document/d/15fSuTmEWKtidAFbaP3m9uMfX4GziJqZnNP385Sel5rM/edit?tab=t.0)).",
@@ -1380,6 +1444,37 @@
         "title": "RikAIResponse"
       },
       "RikAIURLRequest": {
+        "examples": [
+          {
+            "inputURL": "https://firebasestorage.googleapis.com/v0/b/lazarus-apis-testing.appspot.com/o/examples%2FSample%20Form.pdf?alt=media&token=5b537052-ea54-4be4-9d36-9620ee994c1c",
+            "question": [
+              [
+                "What is the name of the patient?"
+              ],
+              [
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
+              ]
+            ],
+            "webhook": "string",
+            "webhookHeaders": {},
+            "webhookSendFull": true,
+            "fileId": "file name",
+            "forceBase64": false,
+            "forceOCR": false,
+            "language": "en",
+            "metadata": {},
+            "ocr": {},
+            "returnOCR": false,
+            "sftp": {
+            "user": "string",
+            "password": "string",
+            "privateKey": "string",
+            "privateKeyPassphrase": "string"
+            },
+            "staticIP": false
+          }
+        ],
         "properties": {
           "inputURL": {
             "type": "string",

--- a/summarizer.openapi.json
+++ b/summarizer.openapi.json
@@ -165,7 +165,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"
@@ -245,7 +245,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. If not present, will default to file name.",
+            "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
             "examples": "file1.pdf"

--- a/summarizer.openapi.json
+++ b/summarizer.openapi.json
@@ -166,8 +166,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceOCR": {
             "type": "boolean",
@@ -245,8 +246,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. If not present, will default to file name.",
-            "setDefault": "file name",
-            "default": "file name"
+            "setDefault": "UUID",
+            "default": "UUID",
+            "examples": "file1.pdf"
           },
           "forceOCR": {
             "type": "boolean",

--- a/summarizer.openapi.json
+++ b/summarizer.openapi.json
@@ -168,7 +168,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceOCR": {
             "type": "boolean",
@@ -248,7 +248,7 @@
             "description": "Custom ID for document. If not present, will default to a random UUID.",
             "setDefault": "UUID",
             "default": "UUID",
-            "examples": "file1.pdf"
+            "examples": ["file1.pdf"]
           },
           "forceOCR": {
             "type": "boolean",


### PR DESCRIPTION
Added request examples to most Riky2 and Rikai2-Extract endpoints
Moved the Riky2 chat endpoint down to the last POST request (makes the diff seem big)
Changed default fileId "UUID" and added example "file1.pdf"