### PR TITLE
Remove Sync Extract Endpoints, formatting, update ApiVersion Default

### DIFF
--- a/custom_rikai.openapi.json
+++ b/custom_rikai.openapi.json
@@ -554,7 +554,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "properties": {
           "base64": {

--- a/custom_rikai.openapi.json
+++ b/custom_rikai.openapi.json
@@ -955,9 +955,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "ocr": {
             "description": "OCR data for the document (entire response from [OCR endpoint](../../ocr/ocr_v2), [example here](https://docs.google.com/document/d/15fSuTmEWKtidAFbaP3m9uMfX4GziJqZnNP385Sel5rM/edit?tab=t.0)). If included, we do not run OCR on the document and use these results instead.",
@@ -1107,9 +1105,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "ocr": {
             "description": "OCR data for the document (entire response from [OCR endpoint](../../ocr/ocr_v2), [example here](https://docs.google.com/document/d/15fSuTmEWKtidAFbaP3m9uMfX4GziJqZnNP385Sel5rM/edit?tab=t.0)). If included, we do not run OCR on the document and use these results instead.",
@@ -1201,9 +1197,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "forceBase64": {
             "type": "boolean",
@@ -1286,9 +1280,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "forceBase64": {
             "type": "boolean",
@@ -1388,9 +1380,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "inputURL": {
             "type": "string",
@@ -1632,9 +1622,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "forceBase64": {
             "type": "boolean",
@@ -1740,9 +1728,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "forceBase64": {
             "type": "boolean",

--- a/custom_rikai.openapi.json
+++ b/custom_rikai.openapi.json
@@ -1847,7 +1847,7 @@
       "apiVersion": {
         "name": "apiVersion",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string",
           "minLength": 1,

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -499,11 +499,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name",
-              [
-                "file1.pdf",
-                "file2.pdf"
-              ]
+              "file name"
             ]
           },
           "forceOCR": {
@@ -694,11 +690,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name",
-              [
-                "file1.pdf",
-                "file2.pdf"
-              ]
+              "file name"
             ]
           },
           "forceBase64": {

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -359,7 +359,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "title": "BulkBase64Request"
       },
@@ -1371,7 +1371,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "title": "ZipBase64Request"
       },

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -459,7 +459,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "webhook": {
@@ -650,7 +650,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "webhook": {
@@ -813,7 +813,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "settings": {
@@ -885,7 +885,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "settings": {
@@ -961,7 +961,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "settings": {
@@ -1042,7 +1042,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "settings": {
@@ -1227,7 +1227,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "settings": {
@@ -1408,7 +1408,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "webhook": {
@@ -1591,7 +1591,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
             ]
           },
           "webhook": {

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -459,7 +459,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "webhook": {
@@ -650,7 +650,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "webhook": {
@@ -813,7 +813,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "settings": {
@@ -885,7 +885,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "settings": {
@@ -961,7 +961,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "settings": {
@@ -1042,7 +1042,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "settings": {
@@ -1227,7 +1227,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "settings": {
@@ -1408,7 +1408,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "webhook": {
@@ -1591,7 +1591,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0}}}"
+              "{\"PatientInfo\": {\"FirstName\": {\"data\": \"Patient first name\", \"page_number\": 0}, \"LastName\": {\"data\": \"Patient last name\", \"page_number\": 0}}}"
             ]
           },
           "webhook": {

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -274,6 +274,9 @@
               }
             }
           },
+          "207": {
+            "$ref": "#/components/responses/207"
+          },
           "400": {
             "$ref": "#/components/responses/400"
           },
@@ -505,7 +508,14 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file."
+            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "examples": [
+              "file name",
+              [
+                "file1.pdf",
+                "file2.pdf"
+              ]
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -699,7 +709,14 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file."
+            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "examples": [
+              "file name",
+              [
+                "file1.pdf",
+                "file2.pdf"
+              ]
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -856,7 +873,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -932,7 +951,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -1012,7 +1033,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1111,7 +1134,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "inputURL": {
             "type": "string",
@@ -1286,7 +1311,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1471,7 +1498,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -1658,7 +1687,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -579,7 +579,7 @@
           },
           "statusId": {
             "type": "object",
-            "description": "List of document IDs for each file uploaded."
+            "description": "A list of document IDs, each representing an uploaded file. Each ID is a randomly generated UUID. These IDs serve as input for retrieving the status of an asynchronous request via the `/rikai/zip/async/{statusId}` endpoint."
           },
           "apiVersion": {
             "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header.",
@@ -1169,7 +1169,7 @@
             "description": "Question and answer data for each question asked in the request."
           },
           "documentId": {
-            "description": "ID for document request or filename if specified.",
+            "description": "The unique identifier for the document. If `fileId` is supplied in the request, it is used as the `documentId`; otherwise, a random UUID is generated.",
             "type": "string"
           },
           "endTime": {
@@ -1530,7 +1530,7 @@
           },
           "documentId": {
             "type": "string",
-            "description": "ID for document request or filename if specified."
+            "description": "The unique identifier for the document. If `fileId` is supplied in the request, it is used as the `documentId`; otherwise, a random UUID is generated."
           },
           "endTime": {
             "type": "integer",
@@ -1562,7 +1562,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "List of document IDs for each file uploaded."
+            "description": "A list of document IDs, each representing an uploaded file. Each ID is a randomly generated UUID. These IDs serve as input for retrieving the status of an asynchronous request via the `/rikai/zip/async/{statusId}` endpoint."
           },
           "warning": {
             "type": "object",

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -108,7 +108,7 @@
     "/rikai/zip/rikai2-extract": {
       "post": {
         "summary": "Document input, ZIP file response",
-        "description": "Make a request to RikAI2-Extract and receive response data in a ZIP file.\n To process your request asynchronously and send the ZIP file to an `outputURL`, include the `async` query parameter. \n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n#### Response zip file contents\n| File  | Description |\n| ----- | ------- |\n| .csv  | CSV containing a breakdown of the itemization |\n| .json | JSON file containing the entire JSON response |\n| .txt  | TXT file containing the entire JSON response |\n| file  | The original uploaded file |\n\nThe default name for the file is an epoch timestamp if `fileId` field is not included in the request.",
+        "description": "Make a request to RikAI2-Extract and receive response data in a ZIP file.\n To process your request asynchronously, include the `async` query parameter. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Receives a [ZIP file](../outputurl) for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead. \n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n",
         "operationId": "post_zip_rikai2_extract",
         "parameters": [
           {
@@ -212,7 +212,7 @@
     "/rikai/bulk/rikai2-extract": {
       "post": {
         "summary": "Bulk file upload",
-        "description": "Upload 1 or more files to RikAI2-Extract for asynchronous processing. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Uploads a ZIP file for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n#### Response zip file contents\n| File  | Description |\n| ----- | ------- |\n| .csv  | CSV containing a breakdown of the itemization |\n| .json | JSON file containing the entire JSON response |\n| .txt  | TXT file containing the entire JSON response |\n| file  | The original uploaded file |\n\nThe default name for the file is an epoch timestamp if a file name could not be extracted from file data.",
+        "description": "Upload 1 or more files to RikAI2-Extract for asynchronous processing. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Receives a [ZIP file](../outputurl) for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n",
         "operationId": "post_bulk_rikai2_extract",
         "parameters": [
           {
@@ -298,7 +298,7 @@
     "/rikai/zip/async/{statusId}": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/rikai2-extract?async=True` or `/rikai/bulk/rikai2-extract`. Identifiable by statusId.",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/rikai2-extract?async=True` or `/rikai/bulk/rikai2-extract`. Identifiable by `statusId`.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -459,18 +459,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "webhook": {
@@ -508,7 +497,7 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name",
               [
@@ -665,18 +654,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "webhook": {
@@ -714,7 +692,7 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name",
               [
@@ -843,18 +821,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "settings": {
@@ -882,7 +849,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -926,18 +893,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "settings": {
@@ -965,7 +921,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1013,18 +969,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "settings": {
@@ -1052,7 +997,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1105,18 +1050,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "settings": {
@@ -1158,7 +1092,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1301,18 +1235,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "settings": {
@@ -1340,7 +1263,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1493,18 +1416,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "webhook": {
@@ -1532,7 +1444,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1687,18 +1599,7 @@
             ],
             "description": "A JSON string or a dictionary containing the question(s) to be asked.",
             "examples": [
-              {
-                "PatientInfo": {
-                  "FirstName": {
-                    "data": "Patient first name",
-                    "page_number": 0
-                  },
-                  "LastName": {
-                    "data": "Patient last name",
-                    "page_number": 0
-                  }
-                }
-              }
+              "{'PatientInfo': {'FirstName': {'data': 'Patient first name', 'page_number': 0}, 'LastName': {'data': 'Patient last name', 'page_number': 0},}}"
             ]
           },
           "webhook": {
@@ -1726,7 +1627,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -554,6 +554,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -760,6 +765,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -889,6 +899,11 @@
           "metadata": {
             "type": "object",
             "description": "Custom JSON to be included in the returned response."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -967,6 +982,11 @@
           "metadata": {
             "type": "object",
             "description": "Custom JSON to be included in the returned response."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1054,6 +1074,11 @@
           "metadata": {
             "type": "object",
             "description": "Custom JSON to be included in the returned response."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1161,6 +1186,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1343,6 +1373,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1539,6 +1574,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1733,6 +1773,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -475,7 +475,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -532,7 +532,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -676,7 +676,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -738,7 +738,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -858,7 +858,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -936,7 +936,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1018,7 +1018,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1105,7 +1105,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1140,7 +1140,7 @@
           },
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "language": {
@@ -1257,7 +1257,7 @@
         "properties": {
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "question": {
@@ -1296,7 +1296,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1474,7 +1474,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -1517,7 +1517,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -1633,7 +1633,7 @@
         "properties": {
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "question": {
@@ -1663,7 +1663,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -1711,7 +1711,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {

--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -52,7 +52,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -149,7 +149,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",

--- a/ocr.openapi.json
+++ b/ocr.openapi.json
@@ -778,7 +778,7 @@
       "apiVersion": {
         "name": "apiVersion",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string",
           "minLength": 1,

--- a/ocr.openapi.json
+++ b/ocr.openapi.json
@@ -670,9 +670,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "forceBase64": {
             "type": "boolean",
@@ -733,9 +731,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document.",
-            "setDefault": "file name",
-            "default": "file name"
+            "description": "Custom ID for document."
           },
           "forceBase64": {
             "type": "boolean",

--- a/old_ocr.openapi.json
+++ b/old_ocr.openapi.json
@@ -730,7 +730,7 @@
       "apiVersion": {
         "name": "apiVersion",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string",
           "minLength": 1,

--- a/old_other_forms.openapi.json
+++ b/old_other_forms.openapi.json
@@ -1980,7 +1980,7 @@
       "apiVersion": {
         "name": "apiVersion",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string",
           "minLength": 1,

--- a/other_forms.openapi.json
+++ b/other_forms.openapi.json
@@ -1771,7 +1771,7 @@
       "apiVersion": {
         "name": "apiVersion",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string",
           "minLength": 1,

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -397,7 +397,7 @@
           },
           "statusId": {
             "type": "object",
-            "description": "List of document IDs for each file uploaded."
+            "description": "A list of document IDs, each representing an uploaded file. Each ID is a randomly generated UUID. These IDs serve as input for retrieving the status of an asynchronous request via the `/rikai/zip/async/{statusId}` endpoint."
           },
           "apiVersion": {
             "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header.",
@@ -976,7 +976,7 @@
             "description": "Question and answer data for each question asked in the request."
           },
           "documentId": {
-            "description": "ID for document request or filename if specified.",
+            "description": "The unique identifier for the document. If `fileId` is supplied in the request, it is used as the `documentId`; otherwise, a random UUID is generated.",
             "type": "string"
           },
           "endTime": {
@@ -1346,7 +1346,7 @@
           },
           "documentId": {
             "type": "string",
-            "description": "ID for document request or filename if specified."
+            "description": "The unique identifier for the document. If `fileId` is supplied in the request, it is used as the `documentId`; otherwise, a random UUID is generated."
           },
           "endTime": {
             "type": "integer",
@@ -1378,7 +1378,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "List of document IDs for each file uploaded."
+            "description": "A list of document IDs, each representing an uploaded file. Each ID is a randomly generated UUID. These IDs serve as input for retrieving the status of an asynchronous request via the `/rikai/zip/async/{statusId}` endpoint."
           },
           "warning": {
             "type": "object",

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -312,11 +312,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name",
-              [
-                "file1.pdf",
-                "file2.pdf"
-              ]
+              "file name"
             ]
           },
           "forceOCR": {
@@ -505,11 +501,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name",
-              [
-                "file1.pdf",
-                "file2.pdf"
-              ]
+              "file name"
             ]
           },
           "forceBase64": {

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -311,7 +311,14 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file."
+            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "examples": [
+              "file name",
+              [
+                "file1.pdf",
+                "file2.pdf"
+              ]
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -493,7 +500,14 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file."
+            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "examples": [
+              "file name",
+              [
+                "file1.pdf",
+                "file2.pdf"
+              ]
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -638,7 +652,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -706,7 +722,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -769,7 +787,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -856,7 +876,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "inputURL": {
             "type": "string",
@@ -1023,7 +1045,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1201,7 +1225,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -1380,7 +1406,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -19,9 +19,9 @@
   "paths": {
     "/rikai/bulk/rikai2": {
       "post": {
-        "summary": "Post Bulk Custom Rikai",
-        "description": "This function queues all of the files in the request to /zip?async=true\nand sends each resulting zip to the output url defined by the user.\n\nArgs:\n    request (Request): fastapi request object\n    req_body (BulkRequestBody): serialized request body model\n    model_id (str): Custom model id from request path parameters\n    org_id (str): Org ID from request headers\n    auth_key (str): Auth Key from request headers\n    api_version (str, optional): User can pass apiVersion in header. Unused here but for documentation purposes.\n    lb_api_version (str, optional): API version header from load balancer. Unused here but for documentation purposes.\n    sub_org_id (str, optional): Sub Org ID from request headers",
-        "operationId": "post_bulk_custom_rikai_rikai_bulk__model_id__post",
+        "summary": "Bulk file upload (async)",
+        "description": "Upload 1 or more files to RikAI2 for asynchronous processing. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Receives a [ZIP file](../outputurl) for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n",
+        "operationId": "post_bulk_rikai2",
         "parameters": [
           {
             "name": "orgId",
@@ -82,15 +82,23 @@
               }
             }
           },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+          "207": {
+            "$ref": "#/components/responses/207"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         }
       }
@@ -98,7 +106,7 @@
     "/rikai/zip/async/{statusId}": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip?async=True` or `/rikai/bulk`. Identifiable by statusId.",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/bulk` or `/rikai/bulk/rikai2`. Identifiable by `statusId`.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -263,8 +271,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -303,7 +310,7 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name",
               [
@@ -457,8 +464,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -497,7 +503,7 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name",
               [
@@ -623,8 +629,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -653,7 +658,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -698,8 +703,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -728,7 +732,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -768,8 +772,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -798,7 +801,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -848,8 +851,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -892,7 +894,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1036,8 +1038,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -1066,7 +1067,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1221,8 +1222,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -1251,7 +1251,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1407,8 +1407,7 @@
           "question": {
             "description": "A string containing the question to be asked.",
             "examples": [
-              "What is the patient's name?",
-              "What is the date of birth?"
+              "What is the name of the patient?"
             ],
             "type": "string"
           },
@@ -1437,7 +1436,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -278,7 +278,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -335,7 +335,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -467,7 +467,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -529,7 +529,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -637,7 +637,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -707,7 +707,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -772,7 +772,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -847,7 +847,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -882,7 +882,7 @@
           },
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "language": {
@@ -1008,7 +1008,7 @@
         "properties": {
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "question": {
@@ -1030,7 +1030,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1201,7 +1201,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -1248,7 +1248,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -1369,7 +1369,7 @@
         "properties": {
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "question": {
@@ -1382,7 +1382,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -1434,7 +1434,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -369,7 +369,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "title": "BulkBase64Request"
       },
@@ -1342,7 +1342,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "title": "ZipBase64Request"
       },

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -17,11 +17,11 @@
     "summary": ""
   },
   "paths": {
-    "/rikai/bulk": {
+    "/rikai/bulk/rikai2": {
       "post": {
-        "summary": "Bulk file upload (async)",
-        "description": "Upload 1 or more files to RikAI2 for asynchronous processing. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Uploads a ZIP file for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n\nThis endpoint functions identically to `/rikai/bulk/rikai2`. You can use either endpoint interchangeably, and both will return the same response.\n\n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n#### Response zip file contents\n| File  | Description |\n| ----- | ------- |\n| .csv  | CSV containing a breakdown of the itemization |\n| .json | JSON file containing the entire JSON response |\n| .txt  | TXT file containing the entire JSON response |\n| file  | The original uploaded file |\n\nThe default name for the file is an epoch timestamp if a file name could not be extracted from file data.",
-        "operationId": "post_bulk_rikai2",
+        "summary": "Post Bulk Custom Rikai",
+        "description": "This function queues all of the files in the request to /zip?async=true\nand sends each resulting zip to the output url defined by the user.\n\nArgs:\n    request (Request): fastapi request object\n    req_body (BulkRequestBody): serialized request body model\n    model_id (str): Custom model id from request path parameters\n    org_id (str): Org ID from request headers\n    auth_key (str): Auth Key from request headers\n    api_version (str, optional): User can pass apiVersion in header. Unused here but for documentation purposes.\n    lb_api_version (str, optional): API version header from load balancer. Unused here but for documentation purposes.\n    sub_org_id (str, optional): Sub Org ID from request headers",
+        "operationId": "post_bulk_custom_rikai_rikai_bulk__model_id__post",
         "parameters": [
           {
             "name": "orgId",
@@ -82,23 +82,15 @@
               }
             }
           },
-          "207": {
-            "$ref": "#/components/responses/207"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          },
-          "502": {
-            "$ref": "#/components/responses/502"
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
         }
       }

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -362,6 +362,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -556,6 +561,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -677,6 +687,11 @@
             "type": "boolean",
             "description": "Set to `true` to include OCR results in response. Does not work if advanced_vision is also set to `true`.",
             "default": false
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -738,6 +753,11 @@
           "metadata": {
             "type": "object",
             "description": "Custom JSON to be included in the returned response."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -812,6 +832,11 @@
           "returnOCR": {
             "type": "boolean",
             "description": "Set to `true` to include OCR results in response. Does not work if advanced_vision is also set to `true`.",
+            "default": false
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
             "default": false
           }
         },
@@ -908,6 +933,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1086,6 +1116,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1275,6 +1310,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1461,6 +1501,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -52,7 +52,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -149,7 +149,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -52,7 +52,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -140,7 +140,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -241,7 +241,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -327,7 +327,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -413,7 +413,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",
@@ -507,7 +507,7 @@
           {
             "name": "apiVersion",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string",
               "title": "apiVersion",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -685,11 +685,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name",
-              [
-                "file1.pdf",
-                "file2.pdf"
-              ]
+              "file name"
             ]
           },
           "forceOCR": {
@@ -879,11 +875,7 @@
             ],
             "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
-              "file name",
-              [
-                "file1.pdf",
-                "file2.pdf"
-              ]
+              "file name"
             ]
           },
           "forceBase64": {

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -660,7 +660,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -717,7 +717,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -859,7 +859,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -921,7 +921,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -1039,7 +1039,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1119,7 +1119,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1194,7 +1194,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1279,7 +1279,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1421,7 +1421,7 @@
         "properties": {
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "question": {
@@ -1453,7 +1453,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "webhookHeaders": {
@@ -1628,7 +1628,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -1675,7 +1675,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {
@@ -1796,7 +1796,7 @@
         "properties": {
           "inputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL for the file to extract data from: Must be a PDF, JPEG, JPG, PNG, TIFF, TIF or TXT."
           },
           "question": {
@@ -1819,7 +1819,7 @@
           },
           "webhook": {
             "type": "string",
-            "pattern": "https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
           "settings": {
@@ -1871,7 +1871,7 @@
           },
           "outputURL": {
             "type": "string",
-            "pattern": "(https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
+            "pattern": " (https?|s?ftp)://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "URL where resulting zip file or JSON can be sent. Must be open to PUT requests."
           },
           "outputURLHeaders": {

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -1114,10 +1114,7 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              [
-                "What is the first medication listed under Section C - Medical Information?",
-                "What is its strength?"
-              ]
+              "Tell me about the history of AI."
             ]
           },
           "webhook": {

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -735,6 +735,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -930,6 +935,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1052,6 +1062,11 @@
             "type": "boolean",
             "description": "Set to `true` to include OCR results in response. Does not work if advanced_vision is also set to `true`.",
             "default": false
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1114,6 +1129,11 @@
           "metadata": {
             "type": "object",
             "description": "Custom JSON to be included in the returned response."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1189,6 +1209,11 @@
           "returnOCR": {
             "type": "boolean",
             "description": "Set to `true` to include OCR results in response. Does not work if advanced_vision is also set to `true`.",
+            "default": false
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
             "default": false
           }
         },
@@ -1267,6 +1292,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1446,6 +1476,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1630,6 +1665,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",
@@ -1817,6 +1857,11 @@
               }
             ],
             "description": "SFTP authentication details. Required for SFTP URLs in `inputURL` or `outputURL`. Option to provide separate server authentication info for `inputURL` and `outputURL`."
+          },
+          "staticIP": {
+            "type": "boolean",
+            "description": "Set to `true` for static IP for webhook and outputURL if they exist",
+            "default": false
           }
         },
         "type": "object",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -440,6 +440,9 @@
               }
             }
           },
+          "207": {
+            "$ref": "#/components/responses/207"
+          },
           "400": {
             "$ref": "#/components/responses/400"
           },
@@ -690,7 +693,14 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file."
+            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "examples": [
+              "file name",
+              [
+                "file1.pdf",
+                "file2.pdf"
+              ]
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -882,7 +892,14 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file."
+            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "examples": [
+              "file name",
+              [
+                "file1.pdf",
+                "file2.pdf"
+              ]
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1037,7 +1054,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -1115,7 +1134,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -1188,7 +1209,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1271,7 +1294,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "language": {
             "type": "string",
@@ -1443,7 +1468,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",
@@ -1625,7 +1652,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceOCR": {
             "type": "boolean",
@@ -1814,7 +1843,9 @@
           "fileId": {
             "type": "string",
             "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
-            "default": "file name"
+            "examples": [
+              "file name"
+            ]
           },
           "forceBase64": {
             "type": "boolean",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -742,7 +742,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "title": "BulkBase64Request"
       },
@@ -1750,7 +1750,7 @@
         "required": [
           "base64",
           "question",
-          "outputURL"
+          "webhook"
         ],
         "title": "ZipBase64Request"
       },

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -663,15 +663,6 @@
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
-          },
           "webhookHeaders": {
             "type": "object",
             "description": "Request headers to include in the POST requests to the webhook."
@@ -862,15 +853,6 @@
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
           },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
-          },
           "webhookHeaders": {
             "type": "object",
             "description": "Request headers to include in the POST requests to the webhook."
@@ -1028,15 +1010,6 @@
               ]
             ]
           },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
-          },
           "webhook": {
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
@@ -1108,15 +1081,6 @@
               ]
             ]
           },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
-          },
           "webhook": {
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
@@ -1182,15 +1146,6 @@
                 "What is the address?"
               ]
             ]
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhook": {
             "type": "string",
@@ -1267,15 +1222,6 @@
                 "What is the address?"
               ]
             ]
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhook": {
             "type": "string",
@@ -1441,15 +1387,6 @@
                 "What is the address?"
               ]
             ]
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhook": {
             "type": "string",
@@ -1630,15 +1567,6 @@
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhookHeaders": {
             "type": "object",
@@ -1821,15 +1749,6 @@
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhookHeaders": {
             "type": "object",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -1134,18 +1134,6 @@
             "description": "Receive the full JSON response at the webhook URL upon request completion. Set to `false` to only receive request status.",
             "default": true
           },
-          "fileId": {
-            "type": "string",
-            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
-            "examples": [
-              "file name"
-            ]
-          },
-          "forceOCR": {
-            "type": "boolean",
-            "description": "Will rasterize a pdf. Set this parameter to `true` only if the input file is a fillable pdf.",
-            "default": false
-          },
           "language": {
             "type": "string",
             "description": "A language code (e.g. 'EN') or the name of the language you wish to translate answers into. [List of supported codes.](../../../prompting-guide/general/faq/#supported-languages)"

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -770,7 +770,7 @@
           },
           "statusId": {
             "type": "object",
-            "description": "List of document IDs for each file uploaded."
+            "description": "A list of document IDs, each representing an uploaded file. Each ID is a randomly generated UUID. These IDs serve as input for retrieving the status of an asynchronous request via the `/rikai/zip/async/{statusId}` endpoint."
           },
           "apiVersion": {
             "description": "API version used for the request. Defaults to the latest production version. To pin to a specific API version, please contact your Lazarus representative to receive the appropriate version header.",
@@ -1335,7 +1335,7 @@
             "description": "Question and answer data for each question asked in the request."
           },
           "documentId": {
-            "description": "ID for document request or filename if specified.",
+            "description": "The unique identifier for the document. If `fileId` is supplied in the request, it is used as the `documentId`; otherwise, a random UUID is generated.",
             "type": "string"
           },
           "endTime": {
@@ -1701,7 +1701,7 @@
           },
           "documentId": {
             "type": "string",
-            "description": "ID for document request or filename if specified."
+            "description": "The unique identifier for the document. If `fileId` is supplied in the request, it is used as the `documentId`; otherwise, a random UUID is generated."
           },
           "endTime": {
             "type": "integer",
@@ -1733,7 +1733,7 @@
           },
           "statusId": {
             "type": "string",
-            "description": "List of document IDs for each file uploaded."
+            "description": "A list of document IDs, each representing an uploaded file. Each ID is a randomly generated UUID. These IDs serve as input for retrieving the status of an asynchronous request via the `/rikai/zip/async/{statusId}` endpoint."
           },
           "warning": {
             "type": "object",

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -274,7 +274,7 @@
     "/rikai/zip/riky2": {
       "post": {
         "summary": "Document input, ZIP file response",
-        "description": "Make a request to RikY2 and receive response data in a ZIP file.\n To process your request asynchronously and send the ZIP file to an `outputURL`, include the `async` query parameter. \n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n#### Response zip file contents\n| File  | Description |\n| ----- | ------- |\n| .csv  | CSV containing a breakdown of the itemization |\n| .json | JSON file containing the entire JSON response |\n| .txt  | TXT file containing the entire JSON response |\n| file  | The original uploaded file |\n\nThe default name for the file is an epoch timestamp if `fileId` field is not included in the request.",
+        "description": "Make a request to RikY2 and receive response data in a ZIP file.\n To process your request asynchronously, include the `async` query parameter. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Receives a [ZIP file](../outputurl) for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n",
         "operationId": "post_zip_riky2",
         "parameters": [
           {
@@ -378,7 +378,7 @@
     "/rikai/bulk/riky2": {
       "post": {
         "summary": "Bulk file upload",
-        "description": "Upload 1 or more files to RikY2 for asynchronous processing. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Uploads a ZIP file for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n#### Response zip file contents\n| File  | Description |\n| ----- | ------- |\n| .csv  | CSV containing a breakdown of the itemization |\n| .json | JSON file containing the entire JSON response |\n| .txt  | TXT file containing the entire JSON response |\n| file  | The original uploaded file |\n\nThe default name for the file is an epoch timestamp if a file name could not be extracted from file data.",
+        "description": "Upload 1 or more files to RikY2 for asynchronous processing. To receive the model output, use either a `webhook` or an `outputURL`:\n- **`webhook` (Recommended)**: Receives a JSON response by default.\n- `outputURL`: Receives a [ZIP file](../outputurl) for each document in the request. If the `returnJSON` parameter is set to true, a JSON file will be provided instead.\n\n\n#### File upload options\nWe only support requests with Content-Type `application/json` at this endpoint.\n- `[application/json]` **inputURL**  link to file\n- `[application/json]` **base64** base64 encoded file data\n\n",
         "operationId": "post_bulk_riky2",
         "parameters": [
           {
@@ -464,7 +464,7 @@
     "/rikai/zip/async/{statusId}": {
       "get": {
         "summary": "Get async request status",
-        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/riky2?async=True` or `/rikai/bulk/riky2`. Identifiable by statusId.",
+        "description": "Retrieves the status of an asynchronous request to `/rikai/zip/riky2?async=True` or `/rikai/bulk/riky2`. Identifiable by `statusId`.",
         "operationId": "get_async_status",
         "parameters": [
           {
@@ -652,13 +652,8 @@
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
               [
-                [
-                  "What is the name of the patient?"
-                ],
-                [
-                  "What is the first medication listed under Section C - Medical Information?",
-                  "What is its strength?"
-                ]
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -666,15 +661,6 @@
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhookHeaders": {
             "type": "object",
@@ -697,7 +683,7 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name",
               [
@@ -859,10 +845,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -870,15 +855,6 @@
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhookHeaders": {
             "type": "object",
@@ -901,7 +877,7 @@
                 "type": "string"
               }
             ],
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name",
               [
@@ -1035,10 +1011,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1058,7 +1033,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1111,10 +1086,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1134,7 +1108,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1182,10 +1156,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1205,7 +1178,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1263,10 +1236,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1286,7 +1258,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1433,10 +1405,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1456,7 +1427,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1613,10 +1584,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1624,15 +1594,6 @@
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhookHeaders": {
             "type": "object",
@@ -1645,7 +1606,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]
@@ -1809,10 +1770,9 @@
             ],
             "description": "A string or list of strings containing the question(s) to be asked.",
             "examples": [
-              "What is the patient's name?",
               [
-                "What is the date of birth?",
-                "What is the address?"
+                "What is the first medication listed under Section C - Medical Information?",
+                "What is its strength?"
               ]
             ]
           },
@@ -1820,15 +1780,6 @@
             "type": "string",
             "pattern": " https?://(?:www\\\\.)?[a-zA-Z0-9./:]+",
             "description": "Webhook URL to which status updates and JSON response will be sent. This is where you will receive the model output. \n[Here](../webhook-examples) is an example of a webhook URL response."
-          },
-          "settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Settings"
-              }
-            ],
-            "description": "Optional user settings.",
-            "type": "object"
           },
           "webhookHeaders": {
             "type": "object",
@@ -1841,7 +1792,7 @@
           },
           "fileId": {
             "type": "string",
-            "description": "Custom ID for document. Requests with multiple files accept unique fileIds for each file.",
+            "description": "Custom ID for uploaded file, returned as `documentId` in the response. Requests with multiple files accept unique fileIds for each file. FileIds can be used to facilitate tracking, referencing, and managing input and output files efficiently.",
             "examples": [
               "file name"
             ]

--- a/summarizer.openapi.json
+++ b/summarizer.openapi.json
@@ -447,7 +447,7 @@
       "apiVersion": {
         "name": "apiVersion",
         "in": "header",
-        "required": true,
+        "required": false,
         "schema": {
           "type": "string",
           "minLength": 1,


### PR DESCRIPTION
Remove Sync Extract Endpoints,
Add space before url string,
Update apiVersion default to 2025-02-27
Make Riky2 Chat question example a string, not array
Delete "async" title that seemingly does nothing but make formatting strange.