### PR TITLE
Default OCR version discrepancy

### DIFF
--- a/extract.openapi.json
+++ b/extract.openapi.json
@@ -841,7 +841,7 @@
       "RikAIOCRRequestBody": {
         "properties": {
           "ocr": {
-            "description": "OCR data for the document (entire response from [OCR endpoint](../../ocr/ocr_v2), [example here](https://lazarus-ai.atlassian.net/wiki/external/YmIwNDNmNWZmNzhhNGYwNDg3MjBlNmFhOTgwMzAwNjc)). Only OCR data obtained from Lazarus endpoints is supported as input.",
+            "description": "OCR data for the document (entire response from [OCR endpoint (version: 2)](../../ocr/ocr_v2), [example here](https://lazarus-ai.atlassian.net/wiki/external/YmIwNDNmNWZmNzhhNGYwNDg3MjBlNmFhOTgwMzAwNjc)). Only OCR data obtained from the Lazarus OCR endpoint (include version: 2 in the header) is supported as input.",
             "type": "object"
           },
           "question": {

--- a/ocr.openapi.json
+++ b/ocr.openapi.json
@@ -227,7 +227,7 @@
           "version": {
             "type": "integer",
             "description": "OCR model version (1 or 2)",
-            "default": 2
+            "default": 1
           }
         }
       },
@@ -299,7 +299,7 @@
           "version": {
             "type": "integer",
             "description": "OCR model version (1 or 2)",
-            "default": 2
+            "default": 1
           }
         }
       },
@@ -595,7 +595,7 @@
           "version": {
             "type": "integer",
             "description": "OCR model version (1 or 2)",
-            "default": 2
+            "default": 1
           }
         },
         "type": "object",
@@ -698,7 +698,7 @@
           "version": {
             "type": "integer",
             "description": "OCR model version (1 or 2)",
-            "default": 2
+            "default": 1
           }
         },
         "type": "object",
@@ -760,7 +760,7 @@
           "version": {
             "type": "integer",
             "description": "OCR model version (1 or 2).",
-            "default": 2
+            "default": 1
           }
         },
         "type": "object",
@@ -837,7 +837,7 @@
           "minLength": 1,
           "title": "version",
           "description": "API version",
-          "default": 2
+          "default": 1
         },
         "description": "API version"
       },

--- a/rikai2.openapi.json
+++ b/rikai2.openapi.json
@@ -837,7 +837,7 @@
       "RikAIOCRRequestBody": {
         "properties": {
           "ocr": {
-            "description": "OCR data for the document (entire response from [OCR endpoint](../../ocr/ocr_v2), [example here](https://lazarus-ai.atlassian.net/wiki/external/YmIwNDNmNWZmNzhhNGYwNDg3MjBlNmFhOTgwMzAwNjc)). Only OCR data obtained from Lazarus endpoints is supported as input.",
+            "description": "OCR data for the document (entire response from [OCR endpoint (version: 2)](../../ocr/ocr_v2), [example here](https://lazarus-ai.atlassian.net/wiki/external/YmIwNDNmNWZmNzhhNGYwNDg3MjBlNmFhOTgwMzAwNjc)). Only OCR data obtained from the Lazarus OCR endpoint (include version: 2 in the header) is supported as input.",
             "type": "object"
           },
           "question": {

--- a/riky2.openapi.json
+++ b/riky2.openapi.json
@@ -1263,7 +1263,7 @@
         ],
         "properties": {
           "ocr": {
-            "description": "OCR data for the document (entire response from [OCR endpoint](../../ocr/ocr_v2), [example here](https://lazarus-ai.atlassian.net/wiki/external/YmIwNDNmNWZmNzhhNGYwNDg3MjBlNmFhOTgwMzAwNjc)). Only OCR data obtained from Lazarus endpoints is supported as input.",
+            "description": "OCR data for the document (entire response from [OCR endpoint (version: 2)](../../ocr/ocr_v2), [example here](https://lazarus-ai.atlassian.net/wiki/external/YmIwNDNmNWZmNzhhNGYwNDg3MjBlNmFhOTgwMzAwNjc)). Only OCR data obtained from the Lazarus OCR endpoint (include version: 2 in the header) is supported as input.",
             "type": "object"
           },
           "question": {


### PR DESCRIPTION
- Set default version of OCR to reflect API behavior
- Warn users that version 2 is required as input to ocr methods