### PR TITLE
Add descriptions of the restrictions on vkg_ids

### DIFF
--- a/vkg.openapi.json
+++ b/vkg.openapi.json
@@ -1554,7 +1554,7 @@
       "vkg-id": {
         "type": "string",
         "title": "VKG ID",
-        "description": "VKG's ID.",
+        "description": "VKG's ID. Must be between 4 and 64 characters (inclusive) and must not contain any of the following characters: ` ! # $ % ^ & * + = } { ; : \\ < > / ? ~ \"",
         "x-stoplight": {
           "id": "hjwh9o5k8qv40"
         }


### PR DESCRIPTION
Add a description of the restrictions on vkg_ids to the create vkg section:
- vkg_ids must be between 4 and 64 characters (inclusive)
- vkg_ids must not contain any of the following characters: ` ! # $ % ^ & * + = } { ; : \ < > / ? ~ "