### PR TITLE
LP-5777: Change metrics_service.openapi.json url port to 8081

### DIFF
--- a/metrics_service.openapi.json
+++ b/metrics_service.openapi.json
@@ -278,7 +278,7 @@
     },
     "servers": [
     {
-      "url": "https://<hostname>:8080",
+      "url": "https://<hostname>:8081",
       "description": ""
     }
   ]


### PR DESCRIPTION
# Updates
- Change metrics_service.openapi.json url port from `8080` to `8081`, since metrics service runs on port `8081`

# Ticket
https://lazarus-ai.atlassian.net/browse/LP-5777