### PR TITLE
LP-5780: Remove version from metrics_service.openapi.json

### DIFF
--- a/metrics_service.openapi.json
+++ b/metrics_service.openapi.json
@@ -11,8 +11,7 @@
         "license": {
             "name": "Get Lazarus",
             "url": "https://emvnha23ura.typeform.com/lazarus-rikai?typeform-source=dashboard.lazarusai.com"
-        },
-        "version": "0.1.0"
+        }
     },
     "paths": {
         "/api/usage": {


### PR DESCRIPTION
# Updates
- Remove (0.1.0) from metrics since it was also removed from RikAI

# Ticket
https://lazarus-ai.atlassian.net/browse/LP-5780

