### PR TITLE
LP-5863 add container-metrics usage response fields

### DIFF
--- a/metrics_service.openapi.json
+++ b/metrics_service.openapi.json
@@ -235,8 +235,10 @@
                     "pages",
                     "questions",
                     "avg_request_time",
+                    "avg_auth_time",
                     "avg_ocr_time",
-                    "avg_model_time"
+                    "avg_model_init_time",
+                    "avg_model_exp_time"
                 ],
                 "title": "UsageMetrics",
                 "description": "Model request usage metrics info."

--- a/metrics_service.openapi.json
+++ b/metrics_service.openapi.json
@@ -205,7 +205,7 @@
                     },
                     "avg_auth_time": {
                         "type": "number",
-                        "title": "Avg Authentication Time",
+                        "title": "Avg Auth Time",
                         "description": "Average authentication time in seconds."
                     },
                     "avg_ocr_time": {

--- a/metrics_service.openapi.json
+++ b/metrics_service.openapi.json
@@ -203,15 +203,25 @@
                         "title": "Avg Request Time",
                         "description": "Average request time in seconds."
                     },
+                    "avg_auth_time": {
+                        "type": "number",
+                        "title": "Avg Authentication Time",
+                        "description": "Average authentication time in seconds."
+                    },
                     "avg_ocr_time": {
                         "type": "number",
                         "title": "Avg Ocr Time",
                         "description": "Average OCR time in seconds."
                     },
-                    "avg_model_time": {
+                    "avg_model_init_time": {
                         "type": "number",
-                        "title": "Avg Model Time",
-                        "description": "Average model time in seconds."
+                        "title": "Avg Init Model Time",
+                        "description": "Average initial model time in seconds."
+                    },
+                    "avg_model_exp_time": {
+                        "type": "number",
+                        "title": "Avg Exp Model Time",
+                        "description": "Average subsequent model time in seconds if `advancedExplainability` is set to true."
                     }
                 },
                 "type": "object",


### PR DESCRIPTION
**summary**
- add time buckets to usage response fields: https://github.com/Lazarus-AI/lazarus-container-metrics/pull/61

**to test**
<img width="781" height="582" alt="Screenshot 2025-10-09 at 1 46 37 PM" src="https://github.com/user-attachments/assets/f75f7170-1354-4be8-bfbe-3678ada06638" />
